### PR TITLE
Add Portuguese localization

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -1,0 +1,71 @@
+{
+  "extensionName": {"message": "TranscripTonic"},
+  "extensionDescription": {"message": "Simple Google Meet transcripts. Private and open source."},
+
+  "autoMode": {"message": "Auto mode"},
+  "autoModeDesc": {"message": "Get transcripts of all meetings"},
+  "manualMode": {"message": "Manual mode"},
+  "manualModeDesc": {"message": "Switch on transcript as needed using the CC icon in Google Meet"},
+  "inBothModes": {
+    "message": "In both modes, transcript will be downloaded as a text file at the end of each meeting. You can also $LINK$ to integrate TranscripTonic with your favourite tools.",
+    "placeholders": {
+      "link": {"content": "<a href=\"meetings.html\" target=\"_blank\"><b>set up webhooks</b></a>"}
+    }
+  },
+  "lastTenMeetings": {"message": "Last 10 meetings ->"},
+  "getHelp": {"message": "Get help"},
+  "reportBug": {"message": "Report a bug"},
+  "notice": {"message": "Notice"},
+  "anotherProject": {"message": "Another project by"},
+
+  "meetingsTitle": {"message": "TranscripTonic—Meetings"},
+  "meetingsHeader": {"message": "TranscripTonic"},
+  "meetingsLastTen": {"message": "Last 10 meetings"},
+  "meetingTitle": {"message": "Meeting title"},
+  "meetingTime": {"message": "Meeting start time and duration"},
+  "webhookStatus": {"message": "Webhook status"},
+  "actions": {"message": "Actions"},
+  "recoverLast": {"message": "Recover last meeting"},
+  "webhooks": {"message": "Webhooks"},
+  "integrate": {"message": "Integrate TranscripTonic with your favourite tools"},
+  "webhookUrl": {"message": "Webhook URL"},
+  "save": {"message": "Save"},
+  "autoPost": {"message": "Automatically post transcript after each meeting, to webhook URL"},
+  "simpleBody": {"message": "Simple webhook body"},
+  "simpleBodyDesc": {"message": "Pre-formatted data, suitable for no-code integrations"},
+  "advancedBody": {"message": "Advanced webhook body"},
+  "advancedBodyDesc": {"message": "Raw data, suitable for code integrations"},
+  "sampleSimple": {"message": "Sample webhook body (simple)"},
+  "sampleAdvanced": {"message": "Sample webhook body (advanced)"},
+
+  "statusSuccessful": {"message": "Successful"},
+  "statusFailed": {"message": "Failed"},
+  "statusNew": {"message": "New"},
+  "statusUnknown": {"message": "Unknown"},
+  "post": {"message": "Post"},
+  "repost": {"message": "Repost"},
+  "posting": {"message": "Posting..."},
+  "reposting": {"message": "Reposting..."},
+  "downloadAlt": {"message": "Download this meeting transcript"},
+  "nextMeetingPlaceholder": {"message": "Your next meeting will show up here"},
+
+  "webhookUrlSaved": {"message": "Webhook URL saved!"},
+  "noWebhooksForYou": {"message": "Fine! No webhooks for you!"},
+  "couldNotDownload": {"message": "Could not download transcript"},
+  "postedSuccessfully": {"message": "Posted successfully!"},
+  "pleaseProvideWebhook": {"message": "Please provide a webhook URL"},
+  "nothingToRecover": {"message": "Nothing to recover—you're on top of the world!"},
+  "recoveredSuccessfully": {"message": "Last meeting recovered successfully!"},
+  "couldNotRecover": {"message": "Could not recover last meeting!"},
+
+  "notifCouldNotPostWebhook": {"message": "Could not post webhook!"},
+  "notifClickToView": {"message": "Click to view status and retry. Check console for more details."},
+
+  "noMeetingsFound": {"message": "No meetings found. May be attend one?"},
+  "emptyTranscript": {"message": "Empty transcript and empty chatMessages"},
+
+  "statusRunning": {"message": "<strong>TranscripTonic is running</strong> <br /> Do not turn off captions"},
+  "statusNotRunning": {"message": "<strong>TranscripTonic is not running</strong> <br /> Turn on captions using the CC icon, if needed"},
+  "bugMessage": {"message": "<strong>TranscripTonic encountered a new error</strong> <br /> Please report it <a href=\"https://github.com/vivek-nexus/transcriptonic/issues\" target=\"_blank\">here</a>."},
+  "reportErrorMessage": {"message": "There is a bug in TranscripTonic. Please report it at https://github.com/vivek-nexus/transcriptonic/issues"}
+}

--- a/extension/_locales/pt/messages.json
+++ b/extension/_locales/pt/messages.json
@@ -1,0 +1,71 @@
+{
+  "extensionName": {"message": "TranscripTonic"},
+  "extensionDescription": {"message": "Transcrições simples do Google Meet. Privado e de código aberto."},
+
+  "autoMode": {"message": "Modo automático"},
+  "autoModeDesc": {"message": "Obter transcrições de todas as reuniões"},
+  "manualMode": {"message": "Modo manual"},
+  "manualModeDesc": {"message": "Ative a transcrição conforme necessário usando o ícone CC no Google Meet"},
+  "inBothModes": {
+    "message": "Nos dois modos, a transcrição será baixada como um arquivo de texto ao final de cada reunião. Você também pode $LINK$ para integrar o TranscripTonic às suas ferramentas favoritas.",
+    "placeholders": {
+      "link": {"content": "<a href=\"meetings.html\" target=\"_blank\"><b>configurar webhooks</b></a>"}
+    }
+  },
+  "lastTenMeetings": {"message": "Últimas 10 reuniões ->"},
+  "getHelp": {"message": "Obter ajuda"},
+  "reportBug": {"message": "Reportar um bug"},
+  "notice": {"message": "Aviso"},
+  "anotherProject": {"message": "Outro projeto de"},
+
+  "meetingsTitle": {"message": "TranscripTonic—Reuniões"},
+  "meetingsHeader": {"message": "TranscripTonic"},
+  "meetingsLastTen": {"message": "Últimas 10 reuniões"},
+  "meetingTitle": {"message": "Título da reunião"},
+  "meetingTime": {"message": "Início e duração da reunião"},
+  "webhookStatus": {"message": "Status do webhook"},
+  "actions": {"message": "Ações"},
+  "recoverLast": {"message": "Recuperar última reunião"},
+  "webhooks": {"message": "Webhooks"},
+  "integrate": {"message": "Integre o TranscripTonic às suas ferramentas favoritas"},
+  "webhookUrl": {"message": "URL do webhook"},
+  "save": {"message": "Salvar"},
+  "autoPost": {"message": "Postar transcrição automaticamente após cada reunião, para a URL do webhook"},
+  "simpleBody": {"message": "Corpo simples"},
+  "simpleBodyDesc": {"message": "Dados pré-formatados, adequados para integrações sem código"},
+  "advancedBody": {"message": "Corpo avançado"},
+  "advancedBodyDesc": {"message": "Dados brutos, adequados para integrações com código"},
+  "sampleSimple": {"message": "Exemplo de corpo (simples)"},
+  "sampleAdvanced": {"message": "Exemplo de corpo (avançado)"},
+
+  "statusSuccessful": {"message": "Sucesso"},
+  "statusFailed": {"message": "Falhou"},
+  "statusNew": {"message": "Novo"},
+  "statusUnknown": {"message": "Desconhecido"},
+  "post": {"message": "Publicar"},
+  "repost": {"message": "Republicar"},
+  "posting": {"message": "Publicando..."},
+  "reposting": {"message": "Republicando..."},
+  "downloadAlt": {"message": "Baixar a transcrição desta reunião"},
+  "nextMeetingPlaceholder": {"message": "Sua próxima reunião aparecerá aqui"},
+
+  "webhookUrlSaved": {"message": "URL do webhook salva!"},
+  "noWebhooksForYou": {"message": "Nada de webhooks para você!"},
+  "couldNotDownload": {"message": "Não foi possível baixar a transcrição"},
+  "postedSuccessfully": {"message": "Publicado com sucesso!"},
+  "pleaseProvideWebhook": {"message": "Forneça uma URL de webhook"},
+  "nothingToRecover": {"message": "Nada para recuperar — você está no topo do mundo!"},
+  "recoveredSuccessfully": {"message": "Última reunião recuperada com sucesso!"},
+  "couldNotRecover": {"message": "Não foi possível recuperar a última reunião!"},
+
+  "notifCouldNotPostWebhook": {"message": "Não foi possível enviar o webhook!"},
+  "notifClickToView": {"message": "Clique para ver o status e tentar novamente. Verifique o console para mais detalhes."},
+
+  "noMeetingsFound": {"message": "Nenhuma reunião encontrada. Que tal participar de uma?"},
+  "emptyTranscript": {"message": "Transcrição e mensagens vazias"},
+
+  "statusRunning": {"message": "<strong>TranscripTonic está em execução</strong> <br /> Não desative as legendas"},
+  "statusNotRunning": {"message": "<strong>TranscripTonic não está em execução</strong> <br /> Ative as legendas pelo ícone CC, se necessário"},
+  "bugMessage": {"message": "<strong>TranscripTonic encontrou um novo erro</strong> <br /> Por favor, reporte em <a href=\"https://github.com/vivek-nexus/transcriptonic/issues\" target=\"_blank\">aqui</a>."},
+  "reportErrorMessage": {"message": "Há um bug no TranscripTonic. Por favor, reporte em https://github.com/vivek-nexus/transcriptonic/issues"}
+}

--- a/extension/background.js
+++ b/extension/background.js
@@ -234,11 +234,11 @@ function pickupLastMeetingFromStorage() {
                     })
                 }
                 else {
-                    reject("Empty transcript and empty chatMessages")
+                    reject(chrome.i18n.getMessage("emptyTranscript"))
                 }
             }
             else {
-                reject("No meetings found. May be attend one?")
+                reject(chrome.i18n.getMessage("noMeetingsFound"))
             }
         })
     })
@@ -410,8 +410,8 @@ function postTranscriptToWebhook(index) {
                                 chrome.notifications.create({
                                     type: "basic",
                                     iconUrl: "icon.png",
-                                    title: "Could not post webhook!",
-                                    message: "Click to view status and retry. Check console for more details."
+                                    title: chrome.i18n.getMessage("notifCouldNotPostWebhook"),
+                                    message: chrome.i18n.getMessage("notifClickToView")
                                 }, function (notificationId) {
                                     // Handle notification click
                                     chrome.notifications.onClicked.addListener(function (clickedNotificationId) {
@@ -516,7 +516,7 @@ function recoverLastMeeting() {
                 }
             }
             else {
-                reject("No meetings found. May be attend one?")
+                reject(chrome.i18n.getMessage("noMeetingsFound"))
             }
         })
     })

--- a/extension/content.js
+++ b/extension/content.js
@@ -7,10 +7,10 @@
 /** @type {ExtensionStatusJSON} */
 const extensionStatusJSON_bug = {
   "status": 400,
-  "message": `<strong>TranscripTonic encountered a new error</strong> <br /> Please report it <a href="https://github.com/vivek-nexus/transcriptonic/issues" target="_blank">here</a>.`
+  "message": chrome.i18n.getMessage("bugMessage")
 }
 
-const reportErrorMessage = "There is a bug in TranscripTonic. Please report it at https://github.com/vivek-nexus/transcriptonic/issues"
+const reportErrorMessage = chrome.i18n.getMessage("reportErrorMessage")
 /** @type {MutationObserverInit} */
 const mutationConfig = { childList: true, attributes: true, subtree: true, characterData: true }
 
@@ -247,7 +247,7 @@ function meetingRoutines(uiType) {
       chrome.storage.sync.get(["operationMode"], function (resultSyncUntyped) {
         const resultSync = /** @type {ResultSync} */ (resultSyncUntyped)
         if (resultSync.operationMode === "manual") {
-          showNotification({ status: 400, message: "<strong>TranscripTonic is not running</strong> <br /> Turn on captions using the CC icon, if needed" })
+          showNotification({ status: 400, message: chrome.i18n.getMessage("statusNotRunning") })
         }
         else {
           showNotification(extensionStatusJSON)
@@ -669,7 +669,7 @@ function checkExtensionStatus() {
   return new Promise((resolve, reject) => {
     // Set default value as 200
     chrome.storage.local.set({
-      extensionStatusJSON: { status: 200, message: "<strong>TranscripTonic is running</strong> <br /> Do not turn off captions" },
+      extensionStatusJSON: { status: 200, message: chrome.i18n.getMessage("statusRunning") },
     })
 
     // https://stackoverflow.com/a/42518434

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "TranscripTonic",
+  "name": "__MSG_extensionName__",
   "version": "3.1.2",
-  "description": "Simple Google Meet transcripts. Private and open source.",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "action": {
     "default_icon": "icon.png",
     "default_popup": "popup.html"

--- a/extension/meetings.html
+++ b/extension/meetings.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TranscripTonic—Meetings</title>
+<title>__MSG_meetingsTitle__</title>
     <style>
         @import url("https://fonts.googleapis.com/css2?family=SUSE:wght@400;700&display=swap");
 
@@ -272,19 +272,19 @@
 </head>
 
 <body>
-    <h1>TranscripTonic</h1>
+    <h1>__MSG_meetingsHeader__</h1>
 
     <div class="grid-container">
         <div>
-            <h2>Last 10 meetings</h2>
+            <h2>__MSG_meetingsLastTen__</h2>
             <div class="transcripts-section">
                 <table>
                     <thead>
                         <tr>
-                            <th>Meeting title</th>
-                            <th>Meeting start time and duration</th>
-                            <th>Webhook status</th>
-                            <th>Actions</th>
+                            <th>__MSG_meetingTitle__</th>
+                            <th>__MSG_meetingTime__</th>
+                            <th>__MSG_webhookStatus__</th>
+                            <th>__MSG_actions__</th>
                         </tr>
                     </thead>
                     <tbody id="transcripts-table">
@@ -292,23 +292,23 @@
                     </tbody>
                 </table>
 
-                <button id="recover-last-meeting">Recover last meeting</button>
+                <button id="recover-last-meeting">__MSG_recoverLast__</button>
             </div>
         </div>
 
         <div>
-            <h2>Webhooks</h2>
+            <h2>__MSG_webhooks__</h2>
             <div class="card">
                 <div class="webhook-header">
                     <!-- <h3>Configure webhooks</h3> -->
-                    <p><b>Integrate TranscripTonic with your favourite tools</b></p>
+                    <p><b>__MSG_integrate__</b></p>
                 </div>
 
                 <form id="webhook-url-form" class="form-field">
-                    <label for="webhook-url">Webhook URL</label>
+                    <label for="webhook-url">__MSG_webhookUrl__</label>
                     <div class="input-group">
                         <input type="url" id="webhook-url" placeholder="https://your-webhook-url.com">
-                        <button id="save-webhook">Save</button>
+                        <button id="save-webhook">__MSG_save__</button>
                     </div>
                 </form>
 
@@ -317,10 +317,7 @@
                 <form class="form-field">
                     <div class="checkbox-group">
                         <input type="checkbox" id="auto-post-webhook" checked>
-                        <label for="auto-post-webhook">
-                            Automatically post transcript after each
-                            meeting, to webhook URL
-                        </label>
+                        <label for="auto-post-webhook">__MSG_autoPost__</label>
                     </div>
                 </form>
 
@@ -329,15 +326,14 @@
                 <form class="form-field">
                     <div class="radio-item">
                         <input type="radio" name="webhook-body-type" id="simple-webhook-body" checked />
-                        <label for="simple-webhook-body"><b>Simple webhook body</b>
-                            <br /><span class="sub-text">Pre-formatted data, suitable for no-code
-                                integrations</span>
+                        <label for="simple-webhook-body"><b>__MSG_simpleBody__</b>
+                            <br /><span class="sub-text">__MSG_simpleBodyDesc__</span>
                         </label>
                     </div>
                     <div class="radio-item">
                         <input type="radio" name="webhook-body-type" id="advanced-webhook-body" />
-                        <label for="advanced-webhook-body"><b>Advanced webhook body</b> <br />
-                            <span class="sub-text">Raw data, suitable for code integrations</span>
+                        <label for="advanced-webhook-body"><b>__MSG_advancedBody__</b> <br />
+                            <span class="sub-text">__MSG_advancedBodyDesc__</span>
                         </label>
                     </div>
                 </form>
@@ -346,7 +342,7 @@
 
             <div class="card">
                 <details>
-                    <summary>Sample webhook body (simple)</summary>
+                    <summary>__MSG_sampleSimple__</summary>
                     <div class="code-block accordion-content">
                         <code>
                         <pre>
@@ -364,7 +360,7 @@
                 </details>
 
                 <details>
-                    <summary>Sample webhook body (advanced)</summary>
+                    <summary>__MSG_sampleAdvanced__</summary>
                     <div class="code-block accordion-content">
                         <code>
                             <pre>

--- a/extension/meetings.js
+++ b/extension/meetings.js
@@ -33,21 +33,21 @@ document.addEventListener("DOMContentLoaded", function () {
                 scrollTo({ top: 0, behavior: "smooth" })
                 if (response.success) {
                     if (response.message === "No recovery needed") {
-                        alert("Nothing to recover—you're on top of the world!")
+                        alert(chrome.i18n.getMessage("nothingToRecover"))
                     }
                     else {
-                        alert("Last meeting recovered successfully!")
+                        alert(chrome.i18n.getMessage("recoveredSuccessfully"))
                     }
                 }
                 else {
                     if (response.message === "No meetings found. May be attend one?") {
-                        alert(response.message)
+                        alert(chrome.i18n.getMessage("noMeetingsFound"))
                     }
                     else if (response.message === "Empty transcript and empty chatMessages") {
-                        alert("Nothing to recover—you're on top of the world!")
+                        alert(chrome.i18n.getMessage("nothingToRecover"))
                     }
                     else {
-                        alert("Could not recover last meeting!")
+                        alert(chrome.i18n.getMessage("couldNotRecover"))
                         console.error(response.message)
                     }
                 }
@@ -95,10 +95,10 @@ document.addEventListener("DOMContentLoaded", function () {
                         autoPostWebhookAfterMeeting: autoPostCheckbox.checked,
                         webhookBodyType: advancedWebhookBodyRadio.checked ? "advanced" : "simple"
                     }, function () {
-                        alert("Webhook URL saved!")
+                        alert(chrome.i18n.getMessage("webhookUrlSaved"))
                     })
                 }).catch((error) => {
-                    alert("Fine! No webhooks for you!")
+                    alert(chrome.i18n.getMessage("noWebhooksForYou"))
                     console.error("Webhook permission error:", error)
                 })
             }
@@ -183,13 +183,13 @@ function loadMeetings() {
                             () => {
                                 switch (meeting.webhookPostStatus) {
                                     case "successful":
-                                        return `<span class="status-success">Successful</span>`
+                                        return `<span class="status-success">${chrome.i18n.getMessage("statusSuccessful")}</span>`
                                     case "failed":
-                                        return `<span class="status-failed">Failed</span>`
+                                        return `<span class="status-failed">${chrome.i18n.getMessage("statusFailed")}</span>`
                                     case "new":
-                                        return `<span class="status-new">New</span>`
+                                        return `<span class="status-new">${chrome.i18n.getMessage("statusNew")}</span>`
                                     default:
-                                        return `<span class="status-new">Unknown</span>`
+                                        return `<span class="status-new">${chrome.i18n.getMessage("statusUnknown")}</span>`
                                 }
                             }
                         )()}
@@ -197,10 +197,10 @@ function loadMeetings() {
                     <td>
                         <div style="min-width: 128px; display: flex; gap: 1rem;">
                             <button class="download-button" data-index="${i}">
-                                <img src="./icons/download.svg" alt="Download this meeting transcript">
+                                <img src="./icons/download.svg" alt="${chrome.i18n.getMessage('downloadAlt')}">
                             </button>
                             <button class="post-button" data-index="${i}">
-                                ${meeting.webhookPostStatus === "new" ? `Post` : `Repost`}
+                                ${meeting.webhookPostStatus === "new" ? chrome.i18n.getMessage("post") : chrome.i18n.getMessage("repost")}
                                 <img src="./icons/webhook.svg" alt="" width="16px">
                             </button>
                         </div>
@@ -223,7 +223,7 @@ function loadMeetings() {
                                 const response = /** @type {ExtensionResponse} */ (responseUntyped)
                                 loadMeetings()
                                 if (!response.success) {
-                                    alert("Could not download transcript")
+                                    alert(chrome.i18n.getMessage("couldNotDownload"))
                                 }
                             })
                         })
@@ -240,7 +240,7 @@ function loadMeetings() {
                                     requestWebhookAndNotificationPermission(resultSync.webhookUrl).then(() => {
                                         // Disable button and update text
                                         webhookPostButton.disabled = true
-                                        webhookPostButton.textContent = meeting.webhookPostStatus === "new" ? "Posting..." : "Reposting..."
+                                        webhookPostButton.textContent = meeting.webhookPostStatus === "new" ? chrome.i18n.getMessage("posting") : chrome.i18n.getMessage("reposting")
 
                                         // Send message to background script to post webhook
                                         const index = parseInt(webhookPostButton.getAttribute("data-index") ?? "-1")
@@ -253,19 +253,19 @@ function loadMeetings() {
                                             const response = /** @type {ExtensionResponse} */ (responseUntyped)
                                             loadMeetings()
                                             if (response.success) {
-                                                alert("Posted successfully!")
+                                                alert(chrome.i18n.getMessage("postedSuccessfully"))
                                             }
                                             else {
                                                 console.error(response.message)
                                             }
                                         })
                                     }).catch((error) => {
-                                        alert("Fine! No webhooks for you!")
+                                        alert(chrome.i18n.getMessage("noWebhooksForYou"))
                                         console.error("Webhook permission error:", error)
                                     })
                                 }
                                 else {
-                                    alert("Please provide a webhook URL")
+                                    alert(chrome.i18n.getMessage("pleaseProvideWebhook"))
                                 }
                             })
                         })
@@ -273,7 +273,7 @@ function loadMeetings() {
                 }
             }
             else {
-                meetingsTable.innerHTML = `<tr><td colspan="4">Your next meeting will show up here</td></tr>`
+                meetingsTable.innerHTML = `<tr><td colspan="4">${chrome.i18n.getMessage("nextMeetingPlaceholder")}</td></tr>`
             }
         }
     })

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-  <title>TranscripTonic</title>
+  <title>__MSG_extensionName__</title>
   <style>
     @import url("https://fonts.googleapis.com/css2?family=SUSE:wght@400;700&display=swap");
 
@@ -136,10 +136,8 @@
     <div class="header">
       <div class="header-content">
         <div class="header-text">
-          <h1>TranscripTonic</h1>
-          <p class="header-description">
-            Simple Google Meet transcripts. Private and open source.
-          </p>
+          <h1>__MSG_extensionName__</h1>
+          <p class="header-description">__MSG_extensionDescription__</p>
         </div>
         <img class="logo" src="./icon.png" alt="Extension icon" />
       </div>
@@ -148,38 +146,36 @@
     <div class="get-started">
       <div class="radio-item">
         <input type="radio" name="mode" id="auto-mode" />
-        <label for="auto-mode"><b>Auto mode</b>
-          <br /><span class="sub-text">Get transcripts of all meetings</span>
+        <label for="auto-mode"><b>__MSG_autoMode__</b>
+          <br /><span class="sub-text">__MSG_autoModeDesc__</span>
         </label>
       </div>
       <div class="radio-item">
         <input type="radio" name="mode" id="manual-mode" />
-        <label for="manual-mode"><b>Manual mode</b> <br />
-          <span class="sub-text">Switch on transcript as needed using the CC icon in Google Meet</span>
+        <label for="manual-mode"><b>__MSG_manualMode__</b> <br />
+          <span class="sub-text">__MSG_manualModeDesc__</span>
         </label>
       </div>
       <hr class="divider" />
-      <p>In both modes, transcript will be downloaded as a text file at the end of each meeting. You can also <a
-          href="meetings.html" target="_blank"><b>set up webhooks</b></a> to integrate TranscripTonic with your
-        favourite tools.</p>
+      <p>__MSG_inBothModes__</p>
     </div>
 
     <div>
       <div class="footer">
-        <a href="./meetings.html" target="_blank">Last 10 meetings -></a>
+        <a href="./meetings.html" target="_blank">__MSG_lastTenMeetings__</a>
         <div>
-          <a href="https://github.com/vivek-nexus/transcriptonic#readme" target="_blank">Get help</a>
+          <a href="https://github.com/vivek-nexus/transcriptonic#readme" target="_blank">__MSG_getHelp__</a>
           <span class="footer-separator">&#9679;</span>
-          <a href="https://github.com/vivek-nexus/transcriptonic/issues" target="_blank">Report a bug</a>
+          <a href="https://github.com/vivek-nexus/transcriptonic/issues" target="_blank">__MSG_reportBug__</a>
         </div>
       </div>
       <p class="footer-link">
         <span>
           <span id="version"></span> /
-          <a href="https://github.com/vivek-nexus/transcriptonic?tab=readme-ov-file#notice" target="_blank">Notice</a>
+          <a href="https://github.com/vivek-nexus/transcriptonic?tab=readme-ov-file#notice" target="_blank">__MSG_notice__</a>
         </span>
         <span>
-          Another project by <a href="https://vivek-nexus.github.io" target="_blank">Vivek</a>
+          __MSG_anotherProject__ <a href="https://vivek-nexus.github.io" target="_blank">Vivek</a>
         </span>
       </p>
     </div>


### PR DESCRIPTION
## Summary
- add Chrome `_locales` for English and Brazilian Portuguese
- localize manifest and HTML pages
- update scripts to use `chrome.i18n` messages
- show translated notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f99ea38908325834b4d95ea95b94a