### PR TITLE
Add customizable transcript filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ View video on [YouTube](https://www.youtube.com/watch?v=ARL6HbkakX4)
 TranscripTonic has two modes of operation.
 
 **In both modes, transcript will be downloaded as a text file at the end of each meeting.**
+You can customize the default folder and filename pattern from the **Last 10 meetings** page.
 
 - **Auto mode:** Automatically records transcripts for all meetings
 - **Manual mode:** Switch on TranscripTonic by clicking on captions icon in Google Meet (CC icon)

--- a/extension/background.js
+++ b/extension/background.js
@@ -273,7 +273,14 @@ function downloadTranscript(index, isWebhookEnabled) {
                 const timestamp = new Date(meeting.meetingStartTimestamp)
                 const formattedTimestamp = timestamp.toLocaleString("default", timeFormat).replace(/[\/:]/g, "-")
 
-                const fileName = `TranscripTonic/Transcript-${sanitisedMeetingTitle} at ${formattedTimestamp}.txt`
+                chrome.storage.sync.get(["downloadFolder", "filenameFormat"], function (resultSyncUntyped) {
+                    const resultSync = /** @type {ResultSync} */ (resultSyncUntyped)
+                    const folder = resultSync.downloadFolder || "TranscripTonic"
+                    const pattern = resultSync.filenameFormat || "Transcript-{title} at {timestamp}.txt"
+                    const processedName = pattern
+                        .replaceAll("{title}", sanitisedMeetingTitle)
+                        .replaceAll("{timestamp}", formattedTimestamp)
+                    const fileName = `${folder}/${processedName}`
 
 
                 // Format transcript and chatMessages content
@@ -336,6 +343,7 @@ function downloadTranscript(index, isWebhookEnabled) {
                         reject(new Error("Failed to read blob"))
                     }
                 }
+            })
             }
             else {
                 reject(new Error("Meeting at specified index not found"))

--- a/extension/meetings.html
+++ b/extension/meetings.html
@@ -403,6 +403,18 @@
                     </div>
                 </details>
             </div>
+
+            <h2>Download settings</h2>
+            <div class="card">
+                <form id="download-settings-form" class="form-field">
+                    <label for="download-folder">Default folder</label>
+                    <input type="text" id="download-folder" placeholder="TranscripTonic">
+                    <label for="filename-format" style="margin-top:1rem;">Filename format</label>
+                    <input type="text" id="filename-format" placeholder="Transcript-{title} at {timestamp}.txt">
+                    <p class="sub-text">Use <code>{title}</code> and <code>{timestamp}</code> in the name.</p>
+                    <button id="save-download-settings">Save</button>
+                </form>
+            </div>
         </div>
     </div>
 

--- a/extension/meetings.js
+++ b/extension/meetings.js
@@ -10,6 +10,10 @@ document.addEventListener("DOMContentLoaded", function () {
     const simpleWebhookBodyRadio = document.querySelector("#simple-webhook-body")
     const advancedWebhookBodyRadio = document.querySelector("#advanced-webhook-body")
     const recoverLastMeetingButton = document.querySelector("#recover-last-meeting")
+    const downloadSettingsForm = document.querySelector("#download-settings-form")
+    const downloadFolderInput = document.querySelector("#download-folder")
+    const filenameFormatInput = document.querySelector("#filename-format")
+    const saveDownloadSettings = document.querySelector("#save-download-settings")
 
     // Initial load of transcripts
     loadMeetings()
@@ -123,6 +127,28 @@ document.addEventListener("DOMContentLoaded", function () {
             // Save webhook URL and settings
             chrome.storage.sync.set({ webhookBodyType: advancedWebhookBodyRadio.checked ? "advanced" : "simple" }, function () { })
         })
+
+    if (downloadSettingsForm instanceof HTMLFormElement && downloadFolderInput instanceof HTMLInputElement && filenameFormatInput instanceof HTMLInputElement && saveDownloadSettings instanceof HTMLButtonElement) {
+        chrome.storage.sync.get(["downloadFolder", "filenameFormat"], function (resultSyncUntyped) {
+            const resultSync = /** @type {ResultSync} */ (resultSyncUntyped)
+            if (resultSync.downloadFolder) {
+                downloadFolderInput.value = resultSync.downloadFolder
+            }
+            if (resultSync.filenameFormat) {
+                filenameFormatInput.value = resultSync.filenameFormat
+            }
+        })
+
+        downloadSettingsForm.addEventListener("submit", function (e) {
+            e.preventDefault()
+            chrome.storage.sync.set({
+                downloadFolder: downloadFolderInput.value || "TranscripTonic",
+                filenameFormat: filenameFormatInput.value || "Transcript-{title} at {timestamp}.txt"
+            }, function () {
+                alert("Download settings saved!")
+            })
+        })
+    }
     }
 })
 

--- a/types/index.js
+++ b/types/index.js
@@ -81,6 +81,8 @@
  * @property {OperationMode} operationMode
  * @property {WebhookBodyType} webhookBodyType
  * @property {WebhookUrl} webhookUrl
+ * @property {DownloadFolder} downloadFolder
+ * @property {FilenameFormat} filenameFormat
  */
 
 /**
@@ -94,6 +96,12 @@
  */
 /**
  * @typedef {string} WebhookUrl URL of the webhook
+ */
+/**
+ * @typedef {string} DownloadFolder default folder to save transcripts
+ */
+/**
+ * @typedef {string} FilenameFormat naming format for downloaded transcripts
  */
 
 


### PR DESCRIPTION
## Summary
- allow configuring filename format and download folder
- add settings UI and logic
- document new options in README

## Testing
- `node --check extension/background.js`
- `node --check extension/meetings.js`


------
https://chatgpt.com/codex/tasks/task_e_683f99b32f788325a223b6d41c98e107